### PR TITLE
Replace templated run code with proper run code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,6 @@ jobs:
          command: |
            if [ "${CIRCLE_BRANCH}" == "master" ]; then
              git push heroku master
-             heroku run python manage.py deploy
+             heroku run npm start deploy
              heroku restart
            fi


### PR DESCRIPTION
I missed a bit of the template that should've been updated. `python manage.py` needed to be `npm start` because that makes sense.